### PR TITLE
Templates/makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,11 @@ copy-ignores.% :
 
 copy:
 	mkdir -p $(target)
-	tar -c --exclude bin --exclude obj --exclude .vs --exclude Properties --exclude *.user $(source) | tar -x --strip-components=2 -C $(target)
+	# Support BSDTAR which is now native on Windows 10, and which is preferred on Windows even though it is unable to do piping! :-/
+	# http://gnuwin32.sourceforge.net/packages/gtar.htm
+	tar -c --exclude bin --exclude obj --exclude .vs --exclude Properties --exclude *.user -f $(target).tar $(source)
+	tar -x --strip-components=2 -C $(target) -f $(target).tar
+	- rm -f $(target).tar
 
 replace-pattern :
 ifneq ("$(wildcard $(output_root)/$(template)-$(suffix)/$(replace_in_file))", "")

--- a/templates/silo-and-client/.github/workflows/ci.yml
+++ b/templates/silo-and-client/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  # push:
+  #   branches: [ master ]
+
+jobs:
+  build-and-test-solution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: build .NET
+      run: make dotnet-build
+    - name: test .NET
+      run: make dotnet-test
+    # - name: build Docker
+    #   run: make docker-build

--- a/templates/silo-and-client/Makefile
+++ b/templates/silo-and-client/Makefile
@@ -31,19 +31,12 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-build dotnet-clean dotnet-test
-	$(MAKE) -f $(silo).Makefile   $@
-
-dotnet-run :
+dotnet-clean dotnet-restore dotnet-build dotnet-test dotnet-publish dotnet-run:
 	$(MAKE) -f $(silo).Makefile   $@
 	$(MAKE) -f $(client).Makefile $@
 
 # Docker commands
-docker-build :
-	$(MAKE) -f   $(silo).Makefile project=$(silo)   config=$(config) container_name=$(container_name) $@
-	$(MAKE) -f $(client).Makefile project=$(client) config=$(config) container_name=$(container_name) $@
-
-docker-push docker-run docker-image-explore docker-show:
+docker-build docker-push docker-run docker-image-explore docker-show:
 	$(MAKE) -f $(silo).Makefile   $@
 	$(MAKE) -f $(client).Makefile $@
 

--- a/templates/silo-and-client/Template.Client.Dockerfile
+++ b/templates/silo-and-client/Template.Client.Dockerfile
@@ -2,7 +2,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 ARG config=Release
 COPY . "/src"
-RUN dotnet publish "/src/Template.Client/Template.Client._PROJ_SUFFIX_" -c ${config} -o /app
+RUN dotnet restore "/src/Template.Client/Template.Client._PROJ_SUFFIX_" -c ${config}
+RUN dotnet build --no-restore "/src/Template.Client/Template.Client._PROJ_SUFFIX_" -c ${config}
+RUN dotnet test --no-build "/src/Template.Client/Template.Client._PROJ_SUFFIX_" -c ${config}
+RUN dotnet publish --no-build  "/src/Template.Client/Template.Client._PROJ_SUFFIX_" -c ${config} -o /app
 
 # container to run the server from
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS release

--- a/templates/silo-and-client/Template.Client.Makefile
+++ b/templates/silo-and-client/Template.Client.Makefile
@@ -2,11 +2,10 @@
 #
 # We'll use some Unix commands here: install git bash with all Unix commands on the PATH
 # We'll need `make`: run `choco install make`
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 # project name
 project:=Template.Client
-project-lc:=$(call lc,$(project))
+project-lc:=$(shell powershell \"$(project)\".ToLower\(\))
 
 # project configuration
 config:=Debug

--- a/templates/silo-and-client/Template.Client.Makefile
+++ b/templates/silo-and-client/Template.Client.Makefile
@@ -29,11 +29,11 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-publish : dotnet-test
+dotnet-publish :
 	dotnet publish --no-build $(project)/$(project)._PROJ_SUFFIX_ -c $(config) -o out/$(project)
 	@echo Built DotNet projects
 
-dotnet-test : dotnet-build
+dotnet-test :
 	dotnet test --no-build $(project).sln -c $(config)
 	@echo Built DotNet projects
 
@@ -41,21 +41,21 @@ dotnet-build : dotnet-restore
 	dotnet build --no-restore $(project).sln -c $(config)
 	@echo Built DotNet projects
 
-dotnet-restore : dotnet-clean
+dotnet-restore :
 	dotnet restore $(project).sln
 	@echo Built DotNet projects
 
-dotnet-clean:
+dotnet-clean :
 	- rm -rf out/$(project)
 	dotnet clean $(project).sln
 
 dotnet-run :
-	powershell Start-Process cmd -ArgumentList '/k','$(project).exe' -WorkingDirectory 'out/$(project)'
+	powershell Start-Process 'out/$(project)/$(project).exe' -WorkingDirectory 'out/$(project)'
 	@echo Launched DotNet projects
 
 # Docker commands
 docker-build :
-	docker build . --rm --build-arg config=$(config) --file Dockerfile --tag $(container_name)
+	docker build . --rm --build-arg config=$(config) --file $(project).Dockerfile --tag $(container_name)
 	@echo Built and tagged images
 
 docker-push :
@@ -63,12 +63,10 @@ docker-push :
 	@echo Pushed images to container registry
 
 docker-run :
-	powershell Start-Process cmd -ArgumentList '/k',\
-	'docker','run','--rm',\
-	'$(container_name)'
+	powershell Start-Process 'docker' -ArgumentList 'run --rm $(container_name)'
 
 docker-run-hostlocal :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-e','ENV_CLUSTER_MODE=HostLocal',\
 	'-e','silo-address=$(silo_address)',\

--- a/templates/silo-and-client/Template.Silo.Dockerfile
+++ b/templates/silo-and-client/Template.Silo.Dockerfile
@@ -2,7 +2,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 ARG config=Release
 COPY . "/src"
-RUN dotnet publish "/src/Template.Silo/Template.Silo._PROJ_SUFFIX_" -c ${config} -o /app
+RUN dotnet restore "/src/Template.Silo/Template.Silo._PROJ_SUFFIX_" -c ${config}
+RUN dotnet build --no-restore "/src/Template.Silo/Template.Silo._PROJ_SUFFIX_" -c ${config}
+RUN dotnet test --no-build "/src/Template.Silo/Template.Silo._PROJ_SUFFIX_" -c ${config}
+RUN dotnet publish --no-build  "/src/Template.Silo/Template.Silo._PROJ_SUFFIX_" -c ${config} -o /app
 
 # container to run the server from
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS release

--- a/templates/silo-and-client/Template.Silo.Makefile
+++ b/templates/silo-and-client/Template.Silo.Makefile
@@ -30,11 +30,11 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-publish : dotnet-test
+dotnet-publish :
 	dotnet publish --no-build $(project)/$(project)._PROJ_SUFFIX_ -c $(config) -o out/$(project)
 	@echo Built DotNet projects
 
-dotnet-test : dotnet-build
+dotnet-test :
 	dotnet test --no-build $(project).sln -c $(config)
 	@echo Built DotNet projects
 
@@ -42,7 +42,7 @@ dotnet-build : dotnet-restore
 	dotnet build --no-restore $(project).sln -c $(config)
 	@echo Built DotNet projects
 
-dotnet-restore : dotnet-clean
+dotnet-restore :
 	dotnet restore $(project).sln
 	@echo Built DotNet projects
 
@@ -51,12 +51,12 @@ dotnet-clean:
 	dotnet clean $(project).sln
 
 dotnet-run :
-	powershell Start-Process cmd -ArgumentList '/k','$(project).exe' -WorkingDirectory 'out/$(project)'
+	powershell Start-Process 'out/$(project)/$(project).exe' -WorkingDirectory 'out/$(project)'
 	@echo Launched DotNet projects
 
 # Docker commands
 docker-build :
-	docker build . --rm --build-arg config=$(config) --file Dockerfile --tag $(container_name)
+	docker build . --rm --build-arg config=$(config) --file $(project).Dockerfile --tag $(container_name)
 	@echo Built and tagged images
 
 docker-push :
@@ -64,7 +64,7 @@ docker-push :
 	@echo Pushed images to container registry
 
 docker-run :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-p','30000:30000',\
 	'-p','11111:11111',\
@@ -73,7 +73,7 @@ docker-run :
 	'$(container_name)'
 
 docker-run-hostlocal :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-e','ENV_CLUSTER_MODE=HostLocal',\
 	'-p','30000:30000',\

--- a/templates/silo-and-client/Template.Silo.Makefile
+++ b/templates/silo-and-client/Template.Silo.Makefile
@@ -3,11 +3,10 @@
 # We'll use some Unix commands here: install git bash with all Unix commands on the PATH
 # We'll need `make`: run `choco install make`
 
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 # project name
 project:=Template.Silo
-project-lc:=$(call lc,$(project))
+project-lc:=$(shell powershell \"$(project)\".ToLower\(\))
 
 # project configuration
 config:=Debug

--- a/templates/standalone-client/.github/workflows/ci.yml
+++ b/templates/standalone-client/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  # push:
+  #   branches: [ master ]
+
+jobs:
+  build-and-test-solution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: build .NET
+      run: make dotnet-build
+    - name: test .NET
+      run: make dotnet-test
+    # - name: build Docker
+    #   run: make docker-build

--- a/templates/standalone-client/Dockerfile
+++ b/templates/standalone-client/Dockerfile
@@ -2,7 +2,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 ARG config=Release
 COPY . "/src"
-RUN dotnet publish "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
+RUN dotnet restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet build --no-restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet test --no-build "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet publish --no-build  "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
 
 # container to run the server from
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS release

--- a/templates/standalone-client/Makefile
+++ b/templates/standalone-client/Makefile
@@ -29,11 +29,11 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-publish : dotnet-test
+dotnet-publish :
 	dotnet publish --no-build $(project)/$(project)._PROJ_SUFFIX_ -c $(config) -o out/$(project)
 	@echo Built DotNet projects
 
-dotnet-test : dotnet-build
+dotnet-test :
 	dotnet test --no-build $(project).sln -c $(config)
 	@echo Built DotNet projects
 
@@ -41,7 +41,7 @@ dotnet-build : dotnet-restore
 	dotnet build --no-restore $(project).sln -c $(config)
 	@echo Built DotNet projects
 
-dotnet-restore : dotnet-clean
+dotnet-restore :
 	dotnet restore $(project).sln
 	@echo Built DotNet projects
 
@@ -50,7 +50,7 @@ dotnet-clean:
 	dotnet clean $(project).sln
 
 dotnet-run :
-	powershell Start-Process cmd -ArgumentList '/k','$(project).exe' -WorkingDirectory 'out/$(project)'
+	powershell Start-Process 'out/$(project)/$(project).exe' -WorkingDirectory 'out/$(project)'
 	@echo Launched DotNet projects
 
 # Docker commands
@@ -63,12 +63,12 @@ docker-push :
 	@echo Pushed images to container registry
 
 docker-run :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'$(container_name)'
 
 docker-run-hostlocal :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-e','ENV_CLUSTER_MODE=HostLocal',\
 	'-e','silo-address=$(silo_address)',\

--- a/templates/standalone-client/Makefile
+++ b/templates/standalone-client/Makefile
@@ -2,11 +2,10 @@
 #
 # We'll use some Unix commands here: install git bash with all Unix commands on the PATH
 # We'll need `make`: run `choco install make`
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 # project name
 project:=Template
-project-lc:=$(call lc,$(project))
+project-lc:=$(shell powershell \"$(project)\".ToLower\(\))
 
 # project configuration
 config:=Debug

--- a/templates/standalone-silo/.github/workflows/ci.yml
+++ b/templates/standalone-silo/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  # push:
+  #   branches: [ master ]
+
+jobs:
+  build-and-test-solution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: build .NET
+      run: make dotnet-build
+    - name: test .NET
+      run: make dotnet-test
+    # - name: build Docker
+    #   run: make docker-build

--- a/templates/standalone-silo/Dockerfile
+++ b/templates/standalone-silo/Dockerfile
@@ -2,7 +2,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 ARG config=Release
 COPY . "/src"
-RUN dotnet publish "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
+RUN dotnet restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet build --no-restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet test --no-build "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet publish --no-build  "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
 
 # container to run the server from
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS release

--- a/templates/standalone-silo/Makefile
+++ b/templates/standalone-silo/Makefile
@@ -3,11 +3,10 @@
 # We'll use some Unix commands here: install git bash with all Unix commands on the PATH
 # We'll need `make`: run `choco install make`
 
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 # project name
 project:=Template
-project-lc:=$(call lc,$(project))
+project-lc:=$(shell powershell \"$(project)\".ToLower\(\))
 
 # project configuration
 config:=Debug

--- a/templates/standalone-silo/Makefile
+++ b/templates/standalone-silo/Makefile
@@ -30,11 +30,11 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-publish : dotnet-test
+dotnet-publish :
 	dotnet publish --no-build $(project)/$(project)._PROJ_SUFFIX_ -c $(config) -o out/$(project)
 	@echo Built DotNet projects
 
-dotnet-test : dotnet-build
+dotnet-test :
 	dotnet test --no-build $(project).sln -c $(config)
 	@echo Built DotNet projects
 
@@ -42,7 +42,7 @@ dotnet-build : dotnet-restore
 	dotnet build --no-restore $(project).sln -c $(config)
 	@echo Built DotNet projects
 
-dotnet-restore : dotnet-clean
+dotnet-restore :
 	dotnet restore $(project).sln
 	@echo Built DotNet projects
 
@@ -51,7 +51,7 @@ dotnet-clean:
 	dotnet clean $(project).sln
 
 dotnet-run :
-	powershell Start-Process cmd -ArgumentList '/k','$(project).exe' -WorkingDirectory 'out/$(project)'
+	powershell Start-Process 'out/$(project)/$(project).exe' -WorkingDirectory 'out/$(project)'
 	@echo Launched DotNet projects
 
 # Docker commands
@@ -64,7 +64,7 @@ docker-push :
 	@echo Pushed images to container registry
 
 docker-run :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-p','30000:30000',\
 	'-p','11111:11111',\
@@ -73,7 +73,7 @@ docker-run :
 	'$(container_name)'
 
 docker-run-hostlocal :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-e','ENV_CLUSTER_MODE=HostLocal',\
 	'-p','30000:30000',\

--- a/templates/webapi-directclient/.github/workflows/ci.yml
+++ b/templates/webapi-directclient/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  # push:
+  #   branches: [ master ]
+
+jobs:
+  build-and-test-solution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: build .NET
+      run: make dotnet-build
+    - name: test .NET
+      run: make dotnet-test
+    # - name: build Docker
+    #   run: make docker-build

--- a/templates/webapi-directclient/Dockerfile
+++ b/templates/webapi-directclient/Dockerfile
@@ -2,7 +2,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 ARG config=Release
 COPY . "/src"
-RUN dotnet publish "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
+RUN dotnet restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet build --no-restore "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet test --no-build "/src/Template/Template._PROJ_SUFFIX_" -c ${config}
+RUN dotnet publish --no-build  "/src/Template/Template._PROJ_SUFFIX_" -c ${config} -o /app
 
 # container to run the server from
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS release

--- a/templates/webapi-directclient/Makefile
+++ b/templates/webapi-directclient/Makefile
@@ -3,11 +3,10 @@
 # We'll use some Unix commands here: install git bash with all Unix commands on the PATH
 # We'll need `make`: run `choco install make`
 
-lc = $(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst F,f,$(subst G,g,$(subst H,h,$(subst I,i,$(subst J,j,$(subst K,k,$(subst L,l,$(subst M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$1))))))))))))))))))))))))))
 
 # project name
 project:=Template
-project-lc:=$(call lc,$(project))
+project-lc:=$(shell powershell \"$(project)\".ToLower\(\))
 
 # project configuration
 config:=Debug

--- a/templates/webapi-directclient/Makefile
+++ b/templates/webapi-directclient/Makefile
@@ -30,11 +30,11 @@ init :
 	git commit -m "Initial commit of Template"
 
 # .NET commands
-dotnet-publish : dotnet-test
+dotnet-publish :
 	dotnet publish --no-build $(project)/$(project)._PROJ_SUFFIX_ -c $(config) -o out/$(project)
 	@echo Built DotNet projects
 
-dotnet-test : dotnet-build
+dotnet-test :
 	dotnet test --no-build $(project).sln -c $(config)
 	@echo Built DotNet projects
 
@@ -42,7 +42,7 @@ dotnet-build : dotnet-restore
 	dotnet build --no-restore $(project).sln -c $(config)
 	@echo Built DotNet projects
 
-dotnet-restore : dotnet-clean
+dotnet-restore :
 	dotnet restore $(project).sln
 	@echo Built DotNet projects
 
@@ -51,7 +51,7 @@ dotnet-clean:
 	dotnet clean $(project).sln
 
 dotnet-run :
-	powershell Start-Process cmd -ArgumentList '/k','$(project).exe' -WorkingDirectory 'out/$(project)'
+	powershell Start-Process 'out/$(project)/$(project).exe' -WorkingDirectory 'out/$(project)'
 	@echo Launched DotNet projects
 
 # Docker commands
@@ -64,7 +64,7 @@ docker-push :
 	@echo Pushed images to container registry
 
 docker-run :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-p','30000:30000',\
 	'-p','11111:11111',\
@@ -73,7 +73,7 @@ docker-run :
 	'$(container_name)'
 
 docker-run-hostlocal :
-	powershell Start-Process cmd -ArgumentList '/k',\
+	powershell Start-Process powershell -ArgumentList \
 	'docker','run','--rm',\
 	'-e','ENV_CLUSTER_MODE=HostLocal',\
 	'-p','30000:30000',\


### PR DESCRIPTION
Makefile cleanup:
* support bsdtar so make can run in cmd shell
* replace subst-based lower-case function with powershell call
* remove need for comspec-based new-window. use powershell instead.
* remove superfluous dependencies for dotnet-restore, dotnet-publish and dotnet-run
add github action CI support
add testing step in Docker build