### PR TITLE
Standardize configuration lookup order; cleanup

### DIFF
--- a/proto-csharp/standalone-silo/Program.cs
+++ b/proto-csharp/standalone-silo/Program.cs
@@ -8,7 +8,7 @@ namespace Template.StandaloneSilo
     /// </summary>
     class SiloConfigurator : Orleans.Contrib.UniversalSilo.SiloConfigurator
     {
-        public SiloConfigurator() : base(false)
+        public SiloConfigurator() : base()
         { }
     }
 
@@ -28,10 +28,10 @@ namespace Template.StandaloneSilo
     /// </summary>
     class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        public static void Main(string[] args) =>
+            CreateHostBuilder(args)
+            .Build()
+            .Run();
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host

--- a/proto-csharp/webapi-directclient/Program.cs
+++ b/proto-csharp/webapi-directclient/Program.cs
@@ -40,7 +40,7 @@ namespace Template.WebApiDirectClient
     /// </summary>
     class SiloConfigurator : Orleans.Contrib.UniversalSilo.SiloConfigurator
     {
-        public SiloConfigurator() : base(false)
+        public SiloConfigurator() : base()
         { }
     }
 
@@ -61,10 +61,10 @@ namespace Template.WebApiDirectClient
     /// </summary>
     class Program
     {
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
+        public static void Main(string[] args) =>
+            CreateHostBuilder(args)
+            .Build()
+            .Run();
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host

--- a/universal-silo/Configuration.fs
+++ b/universal-silo/Configuration.fs
@@ -12,22 +12,30 @@ open Microsoft.Extensions.Hosting
 
 [<AutoOpen>]
 module Keys =
+
+    let [<Literal>] ENV_SILO_ADDRESS                           = "silo-address"
+
     let [<Literal>] ENV_CLUSTER_ID                             = "ENV_CLUSTER_ID"
     let [<Literal>] ENV_SERVICE_ID                             = "ENV_SERVICE_ID"
     let [<Literal>] ENV_SILO_PORT                              = "ENV_SILO_PORT"
     let [<Literal>] ENV_GATEWAY_PORT                           = "ENV_GATEWAY_PORT"
+
     let [<Literal>] ENV_CLUSTER_MODE                           = "ENV_CLUSTER_MODE"
-    let [<Literal>] ENV_PERSISTENCE_MODE                       = "ENV_PERSISTENCE_MODE"
     let [<Literal>] ENV_CLUSTER_AZURE_STORAGE                  = "ENV_CLUSTER_AZURE_STORAGE"
-    let [<Literal>] ENV_DEFAULT_CLUSTER_AZURE_STORAGE          = "ENV_DEFAULT_CLUSTER_AZURE_STORAGE"
+
+    let [<Literal>] ENV_PERSISTENCE_MODE                       = "ENV_PERSISTENCE_MODE"
     let [<Literal>] ENV_PERSISTENCE_AZURE_TABLE                = "ENV_PERSISTENCE_AZURE_TABLE"
-    let [<Literal>] ENV_DEFAULT_PERSISTENCE_AZURE_TABLE        = "ENV_DEFAULT_PERSISTENCE_AZURE_TABLE"
     let [<Literal>] ENV_PERSISTENCE_AZURE_BLOB                 = "ENV_PERSISTENCE_AZURE_BLOB"
-    let [<Literal>] ENV_DEFAULT_PERSISTENCE_AZURE_BLOB         = "ENV_DEFAULT_PERSISTENCE_AZURE_BLOB"
-    let [<Literal>] ENV_DATA_STORAGE_CONNECTION_STRING         = "ENV_DATA_STORAGE_CONNECTION_STRING"
-    let [<Literal>] ENV_DEFAULT_DATA_STORAGE_CONNECTION_STRING = "ENV_DEFAULT_DATA_STORAGE_CONNECTION_STRING"
-    let [<Literal>] ENV_DATA_STORAGE_COLLECTION_NAME           = "ENV_DATA_STORAGE_COLLECTION_NAME"
+
     let [<Literal>] ENV_APPINSIGHTS_KEY                        = "APPINSIGHTS_INSTRUMENTATIONKEY"
+
+    let [<Literal>] ENV_DATA_STORAGE_CONNECTION_STRING         = "ENV_DATA_STORAGE_CONNECTION_STRING"
+    let [<Literal>] ENV_DATA_STORAGE_COLLECTION_NAME           = "ENV_DATA_STORAGE_COLLECTION_NAME"
+
+    let [<Literal>] ENV_DEFAULT_CLUSTER_AZURE_STORAGE          = "ENV_DEFAULT_CLUSTER_AZURE_STORAGE"
+    let [<Literal>] ENV_DEFAULT_PERSISTENCE_AZURE_TABLE        = "ENV_DEFAULT_PERSISTENCE_AZURE_TABLE"
+    let [<Literal>] ENV_DEFAULT_PERSISTENCE_AZURE_BLOB         = "ENV_DEFAULT_PERSISTENCE_AZURE_BLOB"
+    let [<Literal>] ENV_DEFAULT_DATA_STORAGE_CONNECTION_STRING = "ENV_DEFAULT_DATA_STORAGE_CONNECTION_STRING"
 
 [<AutoOpen>]
 module Enumerations =
@@ -43,77 +51,70 @@ module Enumerations =
     | AzureBlob            = 2
     //| CosmosDB             = 3
 
+module StringOps =
+    let [<Literal>] TruncatedLength = 16
+    let truncateSecretString (s : String) =
+        if (String.IsNullOrWhiteSpace s) then
+            String.Empty
+        else if (s.Length <= TruncatedLength + 1) then
+            s
+        else
+            sprintf "%s..." s.[0..TruncatedLength]
+
+type SiloConfiguration() = class
+    member val ClusterId   = "development"    with get, set
+    member val ServiceId   = "universal-silo" with get, set
+    member val SiloPort    = 11111            with get, set
+    member val GatewayPort = 30000            with get, set
+
+    override this.ToString() =
+        sprintf "{ ClusterId : '%s'; ServiceId : '%s'; SiloPort : %d; GatewayPort : %d }"
+            this.ClusterId
+            this.ServiceId
+            this.SiloPort
+            this.GatewayPort
+end
+
+type ClusteringConfiguration() = class
+    member val ClusteringMode   = ClusteringModes.HostLocal    with get, set
+    member val ConnectionString = "UseDevelopmentStorage=true" with get, set
+    member val SiloAddress      = IPAddress.None               with get, set
+
+    override this.ToString() =
+        sprintf "{ ClusteringMode : %A; SiloAddress : %O; ConnectionString : '%s' }"
+            this.ClusteringMode
+            this.SiloAddress
+            (StringOps.truncateSecretString this.ConnectionString)
+end
+
+type StorageProviderConfiguration() = class
+    member val PersistenceMode  = PersistenceModes.InMemory    with get, set
+    member val ConnectionString = "UseDevelopmentStorage=true" with get, set
+
+    override this.ToString() =
+        sprintf "{ PersistenceMode : %A; ConnectionString : '%s' }"
+            this.PersistenceMode
+            (StringOps.truncateSecretString this.ConnectionString)
+end
+
+type TelemetryConfiguration() = class
+    member val ApplicationInsightsKey = String.Empty with get, set
+
+    override this.ToString() =
+        sprintf "{ ApplicationInsightsKey : '%s' }"
+            (StringOps.truncateSecretString this.ApplicationInsightsKey)
+end
+
+type UniversalSiloConfiguration = {
+    SiloConfiguration : SiloConfiguration
+    ClusteringConfiguration : ClusteringConfiguration
+    StorageProviderConfiguration : StorageProviderConfiguration
+    TelemetryConfiguration : TelemetryConfiguration
+}
 
 [<AutoOpen>]
 [<Extension>]
 module Extensions =
-    type internal IConfiguration with
-        member this.AzureClusteringConnectionString =
-            "UseDevelopmentStorage=true"
-            |> this.[ENV_DEFAULT_CLUSTER_AZURE_STORAGE].StringOrDefault
-            |> this.[ENV_CLUSTER_AZURE_STORAGE].StringOrDefault
-
-        member this.AzureTableStorageConnectionString =
-            "UseDevelopmentStorage=true"
-            |> this.[ENV_DEFAULT_PERSISTENCE_AZURE_TABLE].StringOrDefault
-            |> this.[ENV_PERSISTENCE_AZURE_TABLE].StringOrDefault
-
-        member this.AzureBlobStorageConnectionString =
-            "UseDevelopmentStorage=true"
-            |> this.[ENV_DEFAULT_PERSISTENCE_AZURE_BLOB].StringOrDefault
-            |> this.[ENV_PERSISTENCE_AZURE_BLOB].StringOrDefault
-
-        member this.SiloAddress     = this.["silo-address"]
-        member this.ClusteringMode  = ClusteringModes.HostLocal |> this.[ENV_CLUSTER_MODE].EnumOrDefault
-        member this.PersistenceMode = PersistenceModes.InMemory |> this.[ENV_PERSISTENCE_MODE].EnumOrDefault
-        member this.SiloPort        = 11111                     |> this.[ENV_SILO_PORT].IntOrDefault
-        member this.GatewayPort     = 30000                     |> this.[ENV_GATEWAY_PORT].IntOrDefault
-        member this.ClusterId       = "development"             |> this.[ENV_CLUSTER_ID].StringOrDefault
-        member this.ServiceId       = "universal-silo"          |> this.[ENV_SERVICE_ID].StringOrDefault
-        member this.AppInsightsKey  = String.Empty              |> this.[ENV_APPINSIGHTS_KEY].StringOrDefault
-
-    /// Returns a silo address set in the $silo-address$ environment variable or command-line argument
-    let [<Extension>] inline GetSiloAddress                     (_this : IConfiguration) = _this.SiloAddress
-
-    /// Returns the clustering mode set in the $ENV_CLUSTER_MODE$ environment variable, or ClusteringModes.HostLocal if not set
-    let [<Extension>] inline GetClusteringMode                  (_this : IConfiguration) = _this.ClusteringMode
-
-    /// Returns the clustering mode set in the $ENV_PERSISTENCE_MODE$ environment variable, or ClusteringModes.HostLocal if not set
-    let [<Extension>] inline GetPeristenceMode                  (_this : IConfiguration) = _this.PersistenceMode
-
-    /// Returns the silo port set in the $ENV_SILO_PORT$ environment variable, or 11111 if not set
-    let [<Extension>] inline GetSiloPort                        (_this : IConfiguration) = _this.SiloPort
-
-    /// Returns the gateway port set in the $ENV_GATEWAY_PORT$ environment variable, or 30000 if not set
-    let [<Extension>] inline GetGatewayPort                     (_this : IConfiguration) = _this.GatewayPort
-
-    /// Returns the cluster id set in the $ENV_CLUSTER_ID$ environment variable, or 'development' if not set
-    let [<Extension>] inline GetClusterId                       (_this : IConfiguration) = _this.ClusterId
-
-    /// Returns the service id set in the $ENV_SERVICE_ID$ environment variable, or 'universal-silo' if not set
-    let [<Extension>] inline GetServiceId                       (_this : IConfiguration) = _this.ServiceId
-
-    /// Returns the service id set in the $ENV_APPINSIGHTS_KEY$ environment variable, or the empty string if not set
-    let [<Extension>] inline GetAppInsightsKey                  (_this : IConfiguration) = _this.AppInsightsKey
-
-    /// Returns the connection string to be used when the ClusteringMode is set to ClusteringModes.Azure.
-    /// Attempts to return the value set in the $ENV_CLUSTER_AZURE_STORAGE$ environment variable. If not set,
-    /// attempts to return the value set in the $ENV_DEFAULT_CLUSTER_AZURE_STORAGE$ environment variable. If not set,
-    /// returns 'UseDevelopmentStorage=true', pointing to the local storage emulator
-    let [<Extension>] inline GetAzureClusteringConnectionString (_this : IConfiguration) = _this.AzureClusteringConnectionString
-
-    /// Returns the connection string to be used when the PersistenceMode is set to PersistenceModes.AzureTable.
-    /// Attempts to return the value set in the $ENV_PERSISTENCE_AZURE_TABLE$ environment variable. If not set,
-    /// attempts to return the value set in the $ENV_DEFAULT_PERSISTENCE_AZURE_TABLE$ environment variable. If not set,
-    /// returns the empty string
-    let [<Extension>] inline GetAzureTableStorageConnectionString (_this : IConfiguration) = _this.AzureTableStorageConnectionString
-
-    /// Returns the connection string to be used when the PersistenceMode is set to PersistenceModes.AzureBlob.
-    /// Attempts to return the value set in the $ENV_PERSISTENCE_AZURE_BLOB$ environment variable. If not set,
-    /// attempts to return the value set in the $ENV_DEFAULT_PERSISTENCE_AZURE_BLOB$ environment variable. If not set,
-    /// returns the empty string
-    let [<Extension>] inline GetAzureBlobStorageConnectionString (_this : IConfiguration) = _this.AzureBlobStorageConnectionString
-
     /// applies `_action` on `this` as an extension method. returns `_this` for further chaining.
     let [<Extension>] inline ApplyConfiguration (_this : 'a) (_action : Func<'a, 'a>) =
         _action.Invoke _this
@@ -121,118 +122,170 @@ module Extensions =
     let [<Extension>] inline ApplyAppConfiguration(_this : IHostBuilder) =
         let configureAppConfiguration (cb : IConfigurationBuilder) =
             cb
-            |> (fun c -> c.SetBasePath(Directory.GetCurrentDirectory()))
-            |> (fun c -> c.AddJsonFile("clustering.json",  optional = true, reloadOnChange = false))
-            |> (fun c -> c.AddJsonFile("persistence.json", optional = true, reloadOnChange = false))
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("clustering.json",  optional = true, reloadOnChange = false)
+                .AddJsonFile("persistence.json", optional = true, reloadOnChange = false)
             |> ignore
-
         _this.ConfigureAppConfiguration configureAppConfiguration
 
 [<AutoOpen>]
-module Clustering =
-    type ClusteringConfigurationObject() = class
-        member val ClusteringMode = ClusteringModes.HostLocal with get, set
-        member val ConnectionString : string = "InMemory" with get, set
-    end
+module Configuration =
+    type IConfiguration with
+        // clustering settings
+        member private this.SiloAddress = this.["silo-address"]
 
-    type ClusteringConfiguration (Logger : ILogger, Configuration : IConfiguration) = class
-        let localConfiguration = new ClusteringConfigurationObject ()
-        do
-            localConfiguration.ClusteringMode <- Configuration.ClusteringMode
-            Logger.LogInformation("Clustering mode from environment is: {ClusteringMode}", localConfiguration.ClusteringMode)
+        member private this.ClusteringMode  def =
+            def
+            |> this.[ENV_CLUSTER_MODE].EnumOrDefault
 
-            match localConfiguration.ClusteringMode with
-            | ClusteringModes.Azure  ->
-                localConfiguration.ConnectionString <- Configuration.AzureClusteringConnectionString
-            | _ ->
-                localConfiguration.ConnectionString <- String.Empty
-            Logger.LogInformation("Connection string from environment is: {ConnectionString}", localConfiguration.ConnectionString)
+        member private this.AzureClusteringConnectionString def =
+            def
+            |> this.[ENV_DEFAULT_CLUSTER_AZURE_STORAGE].StringOrDefault
+            |> this.[ENV_CLUSTER_AZURE_STORAGE].StringOrDefault
 
-            if (localConfiguration.ClusteringMode = ClusteringModes.HostLocal) then
-                Logger.LogInformation("Blanking connection string because we are running with HostLocal clustering")
-                localConfiguration.ConnectionString <- String.Empty
+        // storage provider settings
+        member private this.PersistenceMode def =
+            def
+            |> this.[ENV_PERSISTENCE_MODE].EnumOrDefault
 
-                if (File.Exists("/.dockerenv")) then
-                    Logger.LogInformation("Deduced we are running within a Docker environment. Resetting ClusteringMode to Docker and blanking connection string")
-                    localConfiguration.ClusteringMode <- ClusteringModes.Docker
+        member private this.AzureTableStorageConnectionString def =
+            def
+            |> this.[ENV_DEFAULT_PERSISTENCE_AZURE_TABLE].StringOrDefault
+            |> this.[ENV_PERSISTENCE_AZURE_TABLE].StringOrDefault
 
-                if (Directory.Exists("/var/run/secrets/kubernetes.io")) then
-                    Logger.LogInformation("Deduced we are running within a Kubernetes environment. Resetting ClusteringMode to Kubernetes and blanking connection string")
-                    localConfiguration.ClusteringMode <- ClusteringModes.Kubernetes
+        member private this.AzureBlobStorageConnectionString def =
+            def
+            |> this.[ENV_DEFAULT_PERSISTENCE_AZURE_BLOB].StringOrDefault
+            |> this.[ENV_PERSISTENCE_AZURE_BLOB].StringOrDefault
 
-            let localConfigurationFile = Configuration.GetSection (nameof(ClusteringConfiguration))
-            if localConfigurationFile.Exists () then
-                localConfigurationFile.Bind(localConfiguration)
-                Logger.LogInformation("Found a clustering configuration. Overriding values with specified values.")
+        // silo settings
+        member private this.ClusterId       def = def |> this.[ENV_CLUSTER_ID].StringOrDefault
+        member private this.ServiceId       def = def |> this.[ENV_SERVICE_ID].StringOrDefault
+        member private this.SiloPort        def = def |> this.[ENV_SILO_PORT].IntOrDefault
+        member private this.GatewayPort     def = def |> this.[ENV_GATEWAY_PORT].IntOrDefault
 
-            Logger.LogInformation("Finally configuring with clustering mode [{ClusteringMode}] with connection string [{ConnectionString}]", localConfiguration.ClusteringMode, localConfiguration.ConnectionString)
+        // telemetry settings
+        member private this.AppInsightsKey  def = def |> this.[ENV_APPINSIGHTS_KEY].StringOrDefault
 
-        /// Returns the ClusteringMode detected from any specified configuration, defaulting to ClusteringModes.HostLocal
-        member val ClusteringMode = localConfiguration.ClusteringMode with get, set
+    let private applyValuesFromConfigurationFiles (config : IConfiguration) (localConfiguration : 'a) =
+        let localConfigurationFile = config.GetSection (typeof<'a>.Name)
+        if localConfigurationFile.Exists () then
+            localConfigurationFile.Bind(localConfiguration)
+        localConfiguration
 
-        /// Returns the connection string detected from any specified configuration, defaulting to the literal string 'InMemory' signifying in memory storage
-        member val ConnectionString = localConfiguration.ConnectionString with get, set
+    let private printConfiguration (logger : ILogger) prefix (c : 'a) =
+        logger.LogInformation ("<{ConfigurationType}> {Message} : Configuration: {Configuration}", (typeof<'a>.Name), prefix, (sprintf "%A" c))
+        c
 
-        /// Returns the IP Address the Silo declares that it is hosted at
-        /// If the clustering configuration is set to ClusteringModes.Docker container, a stable, non-loopback IP address is detected and used
-        /// If the clustering configuration is set to ClusteringModes.Azure or ClusteringModes.Kubernetes, no IP address is returned as this should be set by the runtime
-        /// If the clustering configuration is set to ClusteringModes.HostLocal, then the loopback IP address is used
-        member this.GetSiloAddress() =
-            match IPAddress.TryParse Configuration.SiloAddress with
-            | (true, result) ->
-                Logger.LogInformation("A silo address was specified in the $silo-address$ environment variable or command line argument. {SiloAddress}", result)
-                result
-            | _ ->
-                match this.ClusteringMode with
-                | ClusteringModes.Docker ->
-                    Logger.LogInformation("Computing a stable IP address for a Docker environment")
-                    StableIpAddress
+    let private buildConfiguration applyValuesFromEnvironment (logger : ILogger) (config : IConfiguration) (defaultSettings : 'a) =
+        defaultSettings
+        |> printConfiguration logger "Initial State"
+        |> applyValuesFromConfigurationFiles config
+        |> printConfiguration logger "Applied values from settings files"
+        |> applyValuesFromEnvironment
+        |> printConfiguration logger "Applied values from environment"
 
-                | ClusteringModes.Azure  | ClusteringModes.Kubernetes ->
-                    Logger.LogInformation("No computed IP address for Azure or Kubernetes clustering!")
-                    IPAddress.None
+    let BuildClusteringConfiguration (logger : ILogger) (config : IConfiguration) (defaultSettings : ClusteringConfiguration) =
+        let applyValuesFromEnvironment (localConfiguration : ClusteringConfiguration) =
+            localConfiguration.ClusteringMode   <- config.ClusteringMode localConfiguration.ClusteringMode
+            localConfiguration.ConnectionString <- config.AzureClusteringConnectionString localConfiguration.ConnectionString
+            localConfiguration
 
-                | ClusteringModes.HostLocal
+        let adjustValuesBasedOnContext (localConfiguration : ClusteringConfiguration) =
+            let connectionString =
+                match localConfiguration.ClusteringMode with
+                | ClusteringModes.Azure  ->
+                    logger.LogInformation("Building connection string for Azure Clustering")
+                    config.AzureClusteringConnectionString localConfiguration.ConnectionString
                 | _ ->
-                    Logger.LogInformation("Using the loopback address for [{ClusteringMode}]", this.ClusteringMode);
-                    IPAddress.Loopback
-    end
+                    logger.LogInformation("Blanking connection string because we are not using Azure Clustering")
+                    String.Empty
 
-[<AutoOpen>]
-module StorageProvider =
-    type StorageProviderConfigurationObject() = class
-        member val PersistenceMode : PersistenceModes = PersistenceModes.InMemory with get, set
-        member val ConnectionString : string = "InMemory" with get, set
-    end
+            let clusteringMode =
+                match localConfiguration.ClusteringMode with
+                | ClusteringModes.HostLocal ->
+                    if (File.Exists("/.dockerenv")) then
+                        logger.LogInformation("Deduced we are running within a Docker environment. Resetting ClusteringMode to Docker")
+                        ClusteringModes.Docker
+                    else if (Directory.Exists("/var/run/secrets/kubernetes.io")) then
+                        logger.LogInformation("Deduced we are running within a Kubernetes environment. Resetting ClusteringMode to Kubernetes")
+                        ClusteringModes.Kubernetes
+                    else
+                        localConfiguration.ClusteringMode
+                | _ ->
+                    localConfiguration.ClusteringMode
+            localConfiguration.ClusteringMode   <- clusteringMode
+            localConfiguration.ConnectionString <- connectionString
+            localConfiguration
 
-    type StorageProviderConfiguration (Logger : ILogger, Configuration : IConfiguration) = class
-        let localConfiguration = new StorageProviderConfigurationObject()
-        do
-            localConfiguration.PersistenceMode <- Configuration.PersistenceMode
-            Logger.LogInformation("Persistence mode from environment is: {PersistenceMode}", localConfiguration.PersistenceMode)
+        let setSiloAddress (localConfiguration : ClusteringConfiguration) =
+            let siloAddress =
+                match IPAddress.TryParse config.SiloAddress with
+                | (true, result) ->
+                    logger.LogInformation("A silo address was specified in the $silo-address$ environment variable or command line argument. {SiloAddress}", result)
+                    result
+                | _ ->
+                    match localConfiguration.ClusteringMode with
+                    | ClusteringModes.Docker ->
+                        logger.LogInformation("Computing a stable IP address for a Docker environment")
+                        StableIpAddress
 
-            match localConfiguration.PersistenceMode with
-            | PersistenceModes.AzureTable ->
-                localConfiguration.ConnectionString <- Configuration.AzureTableStorageConnectionString
-            | PersistenceModes.AzureBlob ->
-                localConfiguration.ConnectionString <- Configuration.AzureBlobStorageConnectionString
-            | _ | PersistenceModes.InMemory ->
-                localConfiguration.ConnectionString <- String.Empty
-            Logger.LogInformation("Connection string from environment is: {ConnectionString}", localConfiguration.ConnectionString)
+                    | ClusteringModes.Azure  | ClusteringModes.Kubernetes ->
+                        logger.LogInformation("No computed IP address for Azure or Kubernetes clustering!")
+                        IPAddress.None
 
-            let localConfigurationFile = Configuration.GetSection (nameof(StorageProviderConfiguration))
-            if localConfigurationFile.Exists () then
-                localConfigurationFile.Bind(localConfiguration)
-                Logger.LogInformation("Found a persistence configuration. Overriding with specified values")
+                    | ClusteringModes.HostLocal
+                    | _ ->
+                        logger.LogInformation("Using the loopback address for [{ClusteringMode}]", localConfiguration.ClusteringMode);
+                        IPAddress.Loopback
+            localConfiguration.SiloAddress <- siloAddress
+            localConfiguration
 
-            Logger.LogInformation
-                ("Finally configuring with persistence mode [{PersistenceMode}] with connection string [{ConnectionString}]",
-                localConfiguration.PersistenceMode,
-                localConfiguration.ConnectionString)
+        defaultSettings
+        |> buildConfiguration applyValuesFromEnvironment logger config
+        |> adjustValuesBasedOnContext
+        |> printConfiguration logger "Adjusted values based on context"
+        |> setSiloAddress
+        |> printConfiguration logger "Final State"
 
-        /// Returns the PersistenceMode detected from any specified configuration, defaulting to PersistenceModes.InMemory
-        member val PersistenceMode = localConfiguration.PersistenceMode with get, set
+    let BuildStorageProviderConfiguration (logger : ILogger) (config : IConfiguration) (defaultSettings : StorageProviderConfiguration) =
+        let applyValuesFromEnvironment (localConfiguration : StorageProviderConfiguration) =
+            localConfiguration.PersistenceMode  <- config.PersistenceMode localConfiguration.PersistenceMode
+            let connectionString =
+                match localConfiguration.PersistenceMode with
+                | PersistenceModes.AzureTable ->
+                    logger.LogInformation("Obtained ConnectionString from Envirornment because PersistenceMode is AzureTable")
+                    config.AzureTableStorageConnectionString localConfiguration.ConnectionString
+                | PersistenceModes.AzureBlob ->
+                    logger.LogInformation("Obtained ConnectionString from Envirornment because PersistenceMode is AzureBlob")
+                    config.AzureBlobStorageConnectionString  localConfiguration.ConnectionString
+                | _ | PersistenceModes.InMemory ->
+                    logger.LogInformation("Blanking connection string because PersistenceMode is {PersistenceMode}", localConfiguration.PersistenceMode)
+                    String.Empty
+            localConfiguration.ConnectionString <- connectionString
+            localConfiguration
 
-        /// Returns the connection string detected from any specified configuration, defaulting to the literal string 'InMemory' signifying in memory storage
-        member val ConnectionString = localConfiguration.ConnectionString with get, set
-    end
+        defaultSettings
+        |> buildConfiguration applyValuesFromEnvironment logger config
+        |> printConfiguration logger "Final State"
+
+    let BuildSiloConfiguration (logger : ILogger) (config : IConfiguration) (defaultSettings : SiloConfiguration) =
+        let applyValuesFromEnvironment (localConfiguration : SiloConfiguration) =
+            localConfiguration.ClusterId   <- config.ClusterId   localConfiguration.ClusterId
+            localConfiguration.ServiceId   <- config.ServiceId   localConfiguration.ServiceId
+            localConfiguration.SiloPort    <- config.SiloPort    localConfiguration.SiloPort
+            localConfiguration.GatewayPort <- config.GatewayPort localConfiguration.GatewayPort
+            localConfiguration
+
+        defaultSettings
+        |> buildConfiguration applyValuesFromEnvironment logger config
+        |> printConfiguration logger "Final State"
+
+    let BuildTelemetryConfiguration (logger : ILogger) (config : IConfiguration) (defaultSettings : TelemetryConfiguration) =
+        let applyValuesFromEnvironment (localConfiguration : TelemetryConfiguration) =
+            localConfiguration.ApplicationInsightsKey  <- config.AppInsightsKey localConfiguration.ApplicationInsightsKey
+            localConfiguration
+
+        defaultSettings
+        |> buildConfiguration applyValuesFromEnvironment logger config
+        |> printConfiguration logger "Final State"

--- a/universal-silo/TestingHost.fs
+++ b/universal-silo/TestingHost.fs
@@ -13,14 +13,15 @@ type TestSiloConfigurator() = class
 
     interface ISiloConfigurator with
         member __.Configure siloBuilder =
-            _configuration <- siloBuilder.GetConfiguration ()
+            _configuration <- siloBuilder.GetConfiguration()
+
             siloBuilder
-            |> (fun sb -> sb.AddMemoryGrainStorageAsDefault())
-            |> (fun sb -> sb.UseInMemoryReminderService())
-            |> (fun sb -> sb.ConfigureApplicationParts(fun parts ->
-                parts.AddFromApplicationBaseDirectory()
-                |> (fun apm -> apm.WithCodeGeneration())
-                |> ignore))
+                .AddMemoryGrainStorageAsDefault()
+                .UseInMemoryReminderService()
+                .ConfigureApplicationParts(fun parts ->
+                    parts.AddFromApplicationBaseDirectory()
+                    |> (fun apm -> apm.WithCodeGeneration())
+                    |> ignore)
             |> ignore
 end
 
@@ -28,11 +29,12 @@ type ClusterFixture() = class
     let mutable _cluster : TestCluster = null
     do
         _cluster <-
-            TestClusterBuilder ()
-            |> (fun tcb -> tcb.ConfigureHostConfiguration(fun builder -> builder.AddEnvironmentVariables () |> ignore))
-            |> (fun tcb -> tcb.AddSiloBuilderConfigurator<TestSiloConfigurator>())
-            |> (fun tcb -> tcb.Build())
-        _cluster.Deploy ()
+            TestClusterBuilder()
+                .ConfigureHostConfiguration(fun builder -> builder.AddEnvironmentVariables () |> ignore)
+                .AddSiloBuilderConfigurator<TestSiloConfigurator>()
+                .Build()
+
+        _cluster.Deploy()
 
     member val Cluster = _cluster with get
 


### PR DESCRIPTION
* use fluent syntax (TIL!)
* fix configuration morass - standardize configuration strategy
* improve logging
* standardize extension API and provide consistent mechanisms for providing overrides.

The configuration lookup order is now:
1. Default in Library Code
1. Override in User Code
1. Settings Files
1. Environment
1. Context-specific adjustment
